### PR TITLE
Add placeholder content to 3D page

### DIFF
--- a/3d.html
+++ b/3d.html
@@ -6,12 +6,85 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>3D - Blue Spruce High School</title>
   <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
 
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f4f4f9;
+      color: #333;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      background-color: #2a5d67;
+      color: white;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    main {
+      flex: 1;
+      padding: 2rem;
+      max-width: 1200px;
+      margin: 0 auto;
+      width: 100%;
+    }
+
+    h1 {
+      margin-bottom: 1rem;
+    }
+
+    .coming-soon {
+      text-align: center;
+      padding: 4rem 2rem;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    .coming-soon h2 {
+      color: #2a5d67;
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
+
+    .coming-soon p {
+      font-size: 1.2rem;
+      color: #666;
+    }
+
+    footer {
+      background-color: white;
+      padding: 1.5rem;
+      text-align: center;
+      color: #666;
+      margin-top: auto;
+    }
   </style>
 </head>
 
 <body>
+  <header>
+    <h1>Blue Spruce High School - 3D Experience</h1>
+  </header>
 
+  <main>
+    <div class="coming-soon">
+      <h2>Coming Soon!</h2>
+      <p>Our interactive 3D campus tour is currently under development.</p>
+      <p>Check back soon to explore our facilities in an immersive way.</p>
+    </div>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 Blue Spruce High School. All rights reserved.</p>
+  </footer>
 </body>
 
 </html>


### PR DESCRIPTION
## What Changed
- Added styling to the 3D page with Blue Spruce brand colors (#2a5d67)
- Implemented a responsive layout with header, main content area, and footer
- Added a 'Coming Soon' placeholder message for the 3D campus tour feature

## Why
- The 3D page was previously empty with no content or styling
- Users visiting this page need to understand that the 3D feature is planned but not yet available
- Maintaining consistent branding across all pages improves the overall site experience
- Provides a better user experience than showing a blank page

## Technical Details
- All styling is inline CSS (no external dependencies)
- Follows the same design pattern as index.html
- Responsive design works on mobile, tablet, and desktop viewports
- Maintains accessibility with proper semantic HTML structure